### PR TITLE
Link to rnet_breakup_vertices in help

### DIFF
--- a/R/slopes.R
+++ b/R/slopes.R
@@ -105,6 +105,9 @@ m2g_i = function(i, m_xyz, lonlat, fun = slope_matrix_weighted) {
 #' and a raster dataset representing the terrain as inputs.
 #' It returns the average gradient of each route feature.
 #'
+#' If calculating slopes associated with OSM data, the results may be better if the
+#' network is first split-up, e.g. using the function [stplanr::rnet_breakup_vertices()] from the
+#' [`stplanr`](https://docs.ropensci.org/stplanr/reference/rnet_breakup_vertices.html) package.
 #' **Note:** The `r` object must have a geometry type of `LINESTRING`.
 #' The `sf::st_cast()` function can convert from `MULTILINESTRING` (and other)
 #' geometries to `LINESTRING`s as follows: `r_linestring = sf::st_cast(r, "LINESTRING")`.


### PR DESCRIPTION
Should link to the stplanr documentation, based on info here: https://roxygen2.r-lib.org/articles/markdown.html#links